### PR TITLE
Improve sizing/scaling behavior of track map

### DIFF
--- a/overlay-map/js/app.coffee
+++ b/overlay-map/js/app.coffee
@@ -33,6 +33,7 @@ app.controller 'SettingsCtrl', ($scope, localStorageService) ->
         trackColor: '#000000'
         trackWidth: 10
         trackOutlineColor: '#FFFFFF'
+        trackAlignment: 'center'
         startFinishColor: '#FF0000'
         sectorColor: '#FFDA59'
         showSectors: false
@@ -54,6 +55,7 @@ app.controller 'SettingsCtrl', ($scope, localStorageService) ->
     settings.trackColor ?= defaultSettings.trackColor
     settings.trackWidth ?= defaultSettings.trackWidth
     settings.trackOutlineColor ?= defaultSettings.trackOutlineColor
+    settings.trackAlignment ?= defaultSettings.trackAlignment
     settings.startFinishColor ?= defaultSettings.startFinishColor
     settings.sectorColor ?= defaultSettings.sectorColor
     settings.showSectors ?= defaultSettings.showSectors
@@ -78,6 +80,7 @@ app.controller 'SettingsCtrl', ($scope, localStorageService) ->
         'trackColor'
         'trackWidth'
         'trackOutlineColor'
+        'trackAlignment'
         'startFinishColor'
         'sectorColor'
         'showSectors'

--- a/overlay-map/js/overlay.coffee
+++ b/overlay-map/js/overlay.coffee
@@ -58,7 +58,7 @@ app.service 'config', ($location) ->
     fps: fps
 
     mapOptions:
-        preserveAspectRatio: 'xMidYMax meet'
+        preserveAspectRatio: getPreserveAspectRatio vars.trackAlignment ? 'center'
         styles:
             track:
                 fill: 'none'
@@ -496,5 +496,17 @@ getLineAngle = (x1, y1, x2, y2) ->
         return 0
 
     return (180 + Math.atan2(-y, -x) * 180 / Math.PI + 360) % 360
+
+getPreserveAspectRatio = (trackAlignment) ->
+    switch trackAlignment
+        when 'top-left'     then 'xMinYMin meet'
+        when 'top'          then 'xMidYMin meet'
+        when 'top-right'    then 'xMaxYMin meet'
+        when 'left'         then 'xMinYMid meet'
+        when 'center'       then 'xMidYMid meet'
+        when 'right'        then 'xMaxYMid meet'
+        when 'bottom-left'  then 'xMinYMax meet'
+        when 'bottom'       then 'xMidYMax meet'
+        when 'bottom-right' then 'xMaxYMax meet'
 
 angular.bootstrap document, [app.name]

--- a/overlay-map/js/overlay.coffee
+++ b/overlay-map/js/overlay.coffee
@@ -58,9 +58,6 @@ app.service 'config', ($location) ->
     fps: fps
 
     mapOptions:
-        dimensions:
-            width: 420
-            height: 324
         preserveAspectRatio: 'xMidYMax meet'
         styles:
             track:
@@ -259,7 +256,7 @@ app.controller 'MapCtrl', ($scope, $element, iRData, config) ->
         if not trackOverlay.tracksById[trackId]
             return
 
-        mapVars.trackMap = SVG('map-overlay').size(config.mapOptions.dimensions.width, config.mapOptions.dimensions.height)
+        mapVars.trackMap = SVG('map-overlay')
 
         for path, i in trackOverlay.tracksById[trackId].paths
             if i == 0
@@ -267,7 +264,10 @@ app.controller 'MapCtrl', ($scope, $element, iRData, config) ->
                 mapVars.track = mapVars.trackMap.path(path).attr(config.mapOptions.styles.track).data('id', 'track')
 
                 dims = mapVars.track.bbox()
-                mapVars.trackMap.attr('viewBox', '0 0 ' + (Math.round(dims.width) + 30) + ' ' + (Math.round(dims.height) + 30))
+                mapWidth = Math.round(dims.width + 40)
+                mapHeight = Math.round(dims.height + 40)
+
+                mapVars.trackMap.attr('viewBox', "0 0 #{mapWidth} #{mapHeight}")
                 mapVars.trackMap.attr('preserveAspectRatio', config.mapOptions.preserveAspectRatio)
             else
                 pit_outline = mapVars.trackMap.path(path).attr(config.mapOptions.styles.pits_outline).back().data('id', 'pit_outline')

--- a/overlay-map/tmpl/settings.html
+++ b/overlay-map/tmpl/settings.html
@@ -70,6 +70,25 @@
 						</div>
 					</div>
 					<div class="form-group">
+						<label for="inputTrackAlignment" class="col-sm-3 control-label">Track Alignment</label>
+						<div class="col-sm-2">
+							<select ng-model="settings.trackAlignment" ng-change="saveSettings()" class="form-control" id="inputTrackAlignment">
+								<option>top-left</option>
+								<option>top</option>
+								<option>top-right</option>
+								<option>left</option>
+								<option>center</option>
+								<option>right</option>
+								<option>bottom-left</option>
+								<option>bottom</option>
+								<option>bottom-right</option>
+							</select>
+						</div>
+						<div class="col-sm-7">
+							<span class="help-block">Track alignment in browser window. <em>Default: center</em></span>
+						</div>
+					</div>
+					<div class="form-group">
 						<label for="inputStartColor" class="col-sm-3 control-label">Start/Finish Line Color</label>
 						<div class="col-sm-2">
 							<input ng-model="settings.startFinishColor" ng-change="saveSettings()" type="text" class="form-control" id="inputStartColor" colorpicker="hex" />

--- a/shared/overlay.less
+++ b/shared/overlay.less
@@ -79,13 +79,12 @@ body {
 // Map 
 
 .map {
-	position: absolute;
-	top: 0;
-	left: 0;
 	.map-overlay {
-		width: 100%;
-		height: 100%;
+		width: 100vw;
+		height: 100vh;
 		svg {
+			width: 100%;
+			height: 100%;
 			text {
 				font-family: 'Segoe UI';
 				font-size: 14px;


### PR DESCRIPTION
Improves the sizing/scaling of the track map by having it scale to 100% of window width/height while keeping the whole track visible and preserving aspect ratio. Browser window size in OBS etc. no longer matters as the map will scale to fit.

Also adds a setting to control alignment of the track map (for non-square track maps), e.g. top-left, top, bottom-right etc. Default is **center**.

